### PR TITLE
Update README.md to list supported meeting platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ Take control of your meetings with Amurex, and let it handle the busywork while 
 3. Enable Developer Mode
 4. Load the unpacked extension
 
+## Supported meeting platforms
+- Google Meet
+
 <div align="center">
   Made with ❤️ for better <del>meetings</del> life
 </div>


### PR DESCRIPTION
This might look like a real nit picky change, my apologies, but let me explain: 

I got really excited about Amurex, it sounds great. But it wasn't until I installed the Chrome extension and reviewed the permissions that I realised it works on meet.google.com only. I assume this means only Google Meet is supported, at least for the moment.

I think it's be nice to point this out in the README to future readers.